### PR TITLE
Update Fastlane to v2.228.0

### DIFF
--- a/fastlane/lib/fastlane/version.rb
+++ b/fastlane/lib/fastlane/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
-  VERSION = '2.225.0'.freeze
+  VERSION = '2.228.0'.freeze
   DESCRIPTION = "The easiest way to automate beta deployments and releases for your iOS and Android apps".freeze
   MINIMUM_XCODE_RELEASE = "7.0".freeze
   RUBOCOP_REQUIREMENT = '1.50.2'.freeze


### PR DESCRIPTION
We're using this fork of Fastlane for beta tester management in the iOS Live app, and need to update it to the latest version. 
